### PR TITLE
Solves #10 , #12

### DIFF
--- a/.github/workflows/nuget_push.yml
+++ b/.github/workflows/nuget_push.yml
@@ -5,7 +5,7 @@ on:
     #tags:
     #  - '1.*'
     tags-ignore:
-      - '2.*'
+      - '3.*'
 
 jobs:
   build:

--- a/src/Validations/Arguments.cs
+++ b/src/Validations/Arguments.cs
@@ -60,6 +60,8 @@ namespace Triplex.Validations
         /// <exception cref="ArgumentNullException">If any paramete is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If <paramref name="value"/> length is zero.</exception>
         /// <exception cref="ArgumentFormatException">If <paramref name="value"/> contains only white-space characters</exception>
+        [Obsolete("Please stop using this method, it will be removed on mayor release 4.x. Use NotEmptyOrWhiteSpaceOnly(string?, string) instead.", error: false)]
+        [DebuggerStepThrough]
         public static string NotNullEmptyOrWhiteSpaceOnly([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName)
             => NullAndEmptyChecks.NotNullEmptyOrWhiteSpaceOnly(value, paramName);
 
@@ -73,8 +75,19 @@ namespace Triplex.Validations
         /// <exception cref="ArgumentNullException">If any paramete is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If <paramref name="value"/> length is zero.</exception>
         /// <exception cref="ArgumentFormatException">If <paramref name="value"/> contains only white-space characters</exception>
+        [Obsolete("Please stop using this method, it will be removed on mayor release 4.x. Use NotEmptyOrWhiteSpaceOnly(string?, string, string) instead.", error: false)]
         [DebuggerStepThrough]
         public static string NotNullEmptyOrWhiteSpaceOnly([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage)
+            => NullAndEmptyChecks.NotNullEmptyOrWhiteSpaceOnly(value, paramName, customMessage);
+
+        /// <inheritdoc cref="NotNullEmptyOrWhiteSpaceOnly(in string?, in string)"/>
+        [DebuggerStepThrough]
+        public static string NotEmptyOrWhiteSpaceOnly([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName)
+            => NullAndEmptyChecks.NotNullEmptyOrWhiteSpaceOnly(value, paramName);
+
+        /// <inheritdoc cref="NotNullEmptyOrWhiteSpaceOnly(in string?, in string, in string)"/>
+        [DebuggerStepThrough]
+        public static string NotEmptyOrWhiteSpaceOnly([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage)
             => NullAndEmptyChecks.NotNullEmptyOrWhiteSpaceOnly(value, paramName, customMessage);
 
         /// <summary>
@@ -86,6 +99,7 @@ namespace Triplex.Validations
         /// <exception cref="ArgumentNullException">If any paramete is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If <paramref name="value"/> length is zero.</exception>
         /// <exception cref="ArgumentFormatException">If <paramref name="value"/> contains only white-space characters</exception>
+        [Obsolete("Please stop using this method, it will be removed on mayor release 4.x. Use NotEmpty(string?, string) instead.", error: false)]
         [DebuggerStepThrough]
         public static string NotNullOrEmpty([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName)
             => NullAndEmptyChecks.NotNullOrEmpty(value, paramName);
@@ -99,8 +113,19 @@ namespace Triplex.Validations
         /// <returns><paramref name="value"/></returns>
         /// <exception cref="ArgumentNullException">If any paramete is <see langword = "null" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If <paramref name="value"/> length is zero.</exception>
+        [Obsolete("Please stop using this method, it will be removed on mayor release 4.x. Use NotEmpty(string?, string, string) instead.", error: false)]
         [DebuggerStepThrough]
         public static string NotNullOrEmpty([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage)
+            => NullAndEmptyChecks.NotNullOrEmpty(value, paramName, customMessage);
+
+        /// <inheritdoc cref="NotNullOrEmpty(in string?, in string)"/>
+        [DebuggerStepThrough]
+        public static string NotEmpty([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName)
+            => NullAndEmptyChecks.NotNullOrEmpty(value, paramName);
+        
+        /// <inheritdoc cref="NotNullOrEmpty(in string?, in string, in string)"/>
+        [DebuggerStepThrough]
+        public static string NotEmpty([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage)
             => NullAndEmptyChecks.NotNullOrEmpty(value, paramName, customMessage);
 
         #endregion

--- a/src/Validations/Arguments.cs
+++ b/src/Validations/Arguments.cs
@@ -122,7 +122,7 @@ namespace Triplex.Validations
         [DebuggerStepThrough]
         public static string NotEmpty([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName)
             => NullAndEmptyChecks.NotNullOrEmpty(value, paramName);
-        
+
         /// <inheritdoc cref="NotNullOrEmpty(in string?, in string, in string)"/>
         [DebuggerStepThrough]
         public static string NotEmpty([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage)
@@ -355,7 +355,7 @@ namespace Triplex.Validations
                 throw new FormatException(validCustomMessage);
             }
         }
-        
+
         private static int[] ToDigitsArray(string notNullValue)
         {
             const int zeroAsciiCode = '0';
@@ -375,12 +375,13 @@ namespace Triplex.Validations
         /// <exception cref="ArgumentNullException">When any parameter is <see langword="null"/></exception>
         /// <exception cref="FormatException">If <paramref name="value"/> is not a valid Base64 String.</exception>
         [DebuggerStepThrough]
-        public static string ValidBase64([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName) {
+        public static string ValidBase64([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName)
+        {
             string validParamName =
                 paramName.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(paramName));
 
             string notNullValue = value.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(validParamName);
-            
+
             return IsBase64String(notNullValue) ? notNullValue : throw new FormatException($"{validParamName} is not a valid Base64 String.");
         }
 
@@ -394,11 +395,12 @@ namespace Triplex.Validations
         /// <exception cref="ArgumentNullException">When any parameter is <see langword="null"/></exception>
         /// <exception cref="FormatException">If <paramref name="value"/> is not a valid Base64 String.</exception>
         [DebuggerStepThrough]
-        public static string ValidBase64([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage) {
+        public static string ValidBase64([ValidatedNotNull] in string? value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage)
+        {
             (string validParamName, string validCustomMessage) =
                 (paramName.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(paramName)),
                  customMessage.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(customMessage)));
-            
+
             string notNullValue = value.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(validParamName, validCustomMessage);
 
             return IsBase64String(notNullValue) ? notNullValue : throw new FormatException(validCustomMessage);
@@ -407,7 +409,7 @@ namespace Triplex.Validations
         private static bool IsBase64String(in string base64)
         {
             Span<byte> buffer = new Span<byte>(new byte[base64.Length]);
-            return Convert.TryFromBase64String(base64, buffer , out int bytesParsed);
+            return Convert.TryFromBase64String(base64, buffer, out int bytesParsed);
         }
 
         #endregion // Known Encodings
@@ -421,10 +423,12 @@ namespace Triplex.Validations
         /// <returns><paramref name="value"/></returns>
         /// <exception cref="ArgumentException">If <paramref name="value"/> is an empty <see cref="Guid"/>.</exception>
         [DebuggerStepThrough]
-        public static Guid NotEmpty(in Guid value, [ValidatedNotNull] in string paramName) {
+        public static Guid NotEmpty(in Guid value, [ValidatedNotNull] in string paramName)
+        {
             string validParamName = paramName.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(paramName));
 
-            if (IsEmpty(value)) {
+            if (IsEmpty(value))
+            {
                 throw new ArgumentException(paramName);
             }
 
@@ -448,13 +452,14 @@ namespace Triplex.Validations
         /// <returns><paramref name="value"/></returns>
         /// <exception cref="ArgumentException">If <paramref name="value"/> is an empty <see cref="Guid"/>.</exception>
         [DebuggerStepThrough]
-        public static Guid NotEmpty(in Guid value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage) 
-        { 
+        public static Guid NotEmpty(in Guid value, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string customMessage)
+        {
             (string validParamName, string validCustomMessage) =
                 (paramName.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(paramName)),
                  customMessage.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(customMessage)));
 
-            if (IsEmpty(value)) {
+            if (IsEmpty(value))
+            {
                 throw new ArgumentException(paramName: paramName, message: validCustomMessage);
             }
 
@@ -473,16 +478,48 @@ namespace Triplex.Validations
         /// <param name="precondition">Boolean expression that must be <see langword="true"/> for the argument check to succeed.</param>
         /// <param name="paramName">Parameter name, from caller's context.</param>
         /// <param name="preconditionDescription">Description for the custom precondition.</param>
-        public static void CompliesWith(in bool precondition, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string preconditionDescription) {
+        [DebuggerStepThrough]
+        public static void CompliesWith(in bool precondition, [ValidatedNotNull] in string paramName, [ValidatedNotNull] in string preconditionDescription)
+        {
             (string validParamName, string validPreconditionDescription) =
                 (paramName.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(paramName)),
                  preconditionDescription.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(preconditionDescription)));
 
-            if (!precondition) {
+            if (!precondition)
+            {
                 throw new ArgumentException(paramName: validParamName, message: validPreconditionDescription);
             }
         }
-        
+
+        /// <summary>
+        /// Checks the given value for <see langword="null"/> and then if the its complies with the validator function. 
+        /// </summary>
+        /// <param name="value">To be validated.</param>
+        /// <param name="validator">Validator function, expecting to return <see langword="true"/> for the argument check to succeed.</param>
+        /// <param name="paramName">Parameter name, from caller's context.</param>
+        /// <param name="preconditionDescription">Description for the custom precondition.</param>
+        /// <typeparam name="TNullable"></typeparam>
+        [DebuggerStepThrough]
+        public static TNullable CompliesWith<TNullable>(
+            [ValidatedNotNull] TNullable? value,
+            [ValidatedNotNull] Func<TNullable, bool> validator,
+            [ValidatedNotNull] string paramName,
+            [ValidatedNotNull] string preconditionDescription)
+                where TNullable : class
+        {
+            TNullable notNullValue = value.ValueOrThrowIfNull(nameof(value));
+            Func<TNullable, bool> notNullValidator = validator.ValueOrThrowIfNull(nameof(validator));
+            string notNullParamName = paramName.ValueOrThrowIfNullZeroLengthOrWhiteSpaceOnly(nameof(paramName));
+            string notNullPreconditionDescription = preconditionDescription.ValueOrThrowIfNull(nameof(preconditionDescription));
+
+            if (!notNullValidator(notNullValue))
+            {
+                throw new ArgumentException(paramName: notNullParamName, message: notNullPreconditionDescription);
+            }
+
+            return notNullValue;
+        }
+
         #endregion //General Purpose Checks
     }
 }

--- a/src/Validations/Validations.csproj
+++ b/src/Validations/Validations.csproj
@@ -34,9 +34,12 @@ Breaking Changes
     - string NotNullEmptyOrWhiteSpaceOnly(in string?, in string, in string)
     - string NotNullOrEmpty(in string?, in string)
     - string NotNullOrEmpty(in string?, in string, in string)
+    - void CompliesWith(in bool, in string, in string)
 
 Features
   - Introduce implicit null check for NotNullEmptyOrWhiteSpaceOnly (now NotEmptyOrWhiteSpaceOnly) and NotNullOrEmpty (now NotEmpty).
+  - T CompliesWith(T?, Func&lt;T, bool&gt;, string, string)
+  - T DoesNotComplyWith(T?, Func&lt;T, bool&gt;, string, string)
         </PackageReleaseNotes>
     </PropertyGroup>
 

--- a/src/Validations/Validations.csproj
+++ b/src/Validations/Validations.csproj
@@ -22,14 +22,21 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageTags>Preconditions;Postconditions;Invariants;DDD;Domain Driven Design</PackageTags>
         <PackageIcon>icon.png</PackageIcon>
-        <Version>2.0.0</Version>
+        <Version>3.0.0-alpha</Version>
         <Nullable>enable</Nullable>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AnalysisLevel>latest</AnalysisLevel>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageReleaseNotes>
 Breaking Changes
-  - Add declare all public parameters doing null-checks as TType? instead of TType to improve developers experience when working with Nullable Context (nullable reference types).
+  - Obsolete members from Triplex.Validations.Arguments:
+    - string NotNullEmptyOrWhiteSpaceOnly(in string?, in string)
+    - string NotNullEmptyOrWhiteSpaceOnly(in string?, in string, in string)
+    - string NotNullOrEmpty(in string?, in string)
+    - string NotNullOrEmpty(in string?, in string, in string)
+
+Features
+  - Introduce implicit null check for NotNullEmptyOrWhiteSpaceOnly (now NotEmptyOrWhiteSpaceOnly) and NotNullOrEmpty (now NotEmpty).
 
 Notes:
   - This version does not introduces compiler errors for 1.x usages but it could introduce (or remove) compiler warnings and that can be considered a breaking change for some teams. Tha's why we changed from 1.x to 2.x, but most users won't experience breaking changes in their builds. 

--- a/src/Validations/Validations.csproj
+++ b/src/Validations/Validations.csproj
@@ -37,9 +37,6 @@ Breaking Changes
 
 Features
   - Introduce implicit null check for NotNullEmptyOrWhiteSpaceOnly (now NotEmptyOrWhiteSpaceOnly) and NotNullOrEmpty (now NotEmpty).
-
-Notes:
-  - This version does not introduces compiler errors for 1.x usages but it could introduce (or remove) compiler warnings and that can be considered a breaking change for some teams. Tha's why we changed from 1.x to 2.x, but most users won't experience breaking changes in their builds. 
         </PackageReleaseNotes>
     </PropertyGroup>
 

--- a/tests/unit/Validations.Tests/ArgumentsFacts/CompliesWithUsingLambdaMessageFacts.cs
+++ b/tests/unit/Validations.Tests/ArgumentsFacts/CompliesWithUsingLambdaMessageFacts.cs
@@ -1,0 +1,47 @@
+using System;
+using NUnit.Framework;
+
+namespace Triplex.Validations.Tests.ArgumentsFacts
+{
+    [TestFixture]
+    internal sealed class CompliesWithUsingLambdaMessageFacts
+    {
+        private const string PreconditionDescription = "Must be true.";
+
+        [Test]
+        public void With_True_Throws_Nothing()
+        {
+            const string? someString = "Hello World!";
+            Assert.That(() => Arguments.CompliesWith(someString, val => val.Length > 2, nameof(someString), PreconditionDescription), Throws.Nothing);
+        }
+
+        [Test]
+        public void Returns_Same_Instance()
+        {
+            const string? someString = "Hello World 85";
+            string notNullValue = Arguments.CompliesWith(someString, val => val.Length > 2, nameof(someString), PreconditionDescription);
+
+            Assert.That(someString, Is.SameAs(notNullValue));
+        }
+
+        [Test]
+        public void With_False_Throws_ArgumentException()
+        {
+            const string? someString = "Hello World 1234";
+            Assert.That(() => Arguments.CompliesWith(someString, val => val.Length > 100, nameof(someString), PreconditionDescription),
+                Throws.ArgumentException
+                      .With.Property(nameof(ArgumentException.ParamName)).EqualTo(nameof(someString))
+                      .And.Message.Contains(PreconditionDescription));
+        }
+
+        [Test]
+        public void With_Invalid_ParamName_Throws_ArgumentException([Values(null, "", " ", "\n\r\t ")] string paramName, [Values] bool precondition)
+        {
+            const string? someString = "Hello World 1235";
+
+            Assert.That(() => Arguments.CompliesWith(someString, val => precondition, paramName, PreconditionDescription),
+                Throws.InstanceOf<ArgumentException>()
+                      .With.Property(nameof(ArgumentException.ParamName)).EqualTo("paramName"));
+        }
+    }
+}

--- a/tests/unit/Validations.Tests/ArgumentsFacts/DoesNotComplyWithMessageFacts.cs
+++ b/tests/unit/Validations.Tests/ArgumentsFacts/DoesNotComplyWithMessageFacts.cs
@@ -4,31 +4,31 @@ using NUnit.Framework;
 namespace Triplex.Validations.Tests.ArgumentsFacts
 {
     [TestFixture]
-    internal sealed class CompliesWithUsingLambdaMessageFacts
+    internal sealed class DoesNotComplyWithMessageFacts
     {
         private const string PreconditionDescription = "Must be true.";
 
         [Test]
-        public void With_True_Throws_Nothing()
+        public void With_False_Throws_Nothing()
         {
             const string? someString = "Hello World!";
-            Assert.That(() => Arguments.CompliesWith(someString, val => val.Length > 2, nameof(someString), PreconditionDescription), Throws.Nothing);
+            Assert.That(() => Arguments.DoesNotComplyWith(someString, val => val.Length == 0, nameof(someString), PreconditionDescription), Throws.Nothing);
         }
 
         [Test]
         public void Returns_Same_Instance()
         {
             const string? someString = "Hello World 85";
-            string notNullValue = Arguments.CompliesWith(someString, val => val.Length > 2, nameof(someString), PreconditionDescription);
+            string notNullValue = Arguments.DoesNotComplyWith(someString, val => val.Length == 0, nameof(someString), PreconditionDescription);
 
             Assert.That(someString, Is.SameAs(notNullValue));
         }
 
         [Test]
-        public void With_False_Throws_ArgumentException()
+        public void With_True_Throws_ArgumentException()
         {
-            const string? someString = "Hello World 1234";
-            Assert.That(() => Arguments.CompliesWith(someString, val => val.Length > 100, nameof(someString), PreconditionDescription),
+            const string? someString = "123456789";
+            Assert.That(() => Arguments.DoesNotComplyWith(someString, val => val.Length == 9, nameof(someString), PreconditionDescription),
                 Throws.ArgumentException
                       .With.Property(nameof(ArgumentException.ParamName)).EqualTo(nameof(someString))
                       .And.Message.Contains(PreconditionDescription));
@@ -39,7 +39,7 @@ namespace Triplex.Validations.Tests.ArgumentsFacts
         {
             const string? someString = "Hello World 1235";
 
-            Assert.That(() => Arguments.CompliesWith(someString, val => precondition, paramName, PreconditionDescription),
+            Assert.That(() => Arguments.DoesNotComplyWith(someString, val => precondition, paramName, PreconditionDescription),
                 Throws.InstanceOf<ArgumentException>()
                       .With.Property(nameof(ArgumentException.ParamName)).EqualTo("paramName"));
         }
@@ -49,7 +49,7 @@ namespace Triplex.Validations.Tests.ArgumentsFacts
         {
             const string? someString = "Hello World 1235";
 
-            Assert.That(() => Arguments.CompliesWith(someString, val => precondition, nameof(someString), description),
+            Assert.That(() => Arguments.DoesNotComplyWith(someString, val => precondition, nameof(someString), description),
                 Throws.InstanceOf<ArgumentException>()
                       .With.Property(nameof(ArgumentException.ParamName)).EqualTo("preconditionDescription"));
         }
@@ -58,7 +58,7 @@ namespace Triplex.Validations.Tests.ArgumentsFacts
         public void With_Null_Value_Throws_ArgumentNullException()
         {
             const string? someString = null;
-            Assert.That(() => Arguments.CompliesWith(someString, val => val.Length > 100, nameof(someString), PreconditionDescription),
+            Assert.That(() => Arguments.DoesNotComplyWith(someString, val => val.Length > 100, nameof(someString), PreconditionDescription),
                 Throws.ArgumentNullException
                       .With.Property(nameof(ArgumentException.ParamName)).EqualTo("value")
                       .And.Message.Contains("cannot be null"));

--- a/tests/unit/Validations.Tests/ArgumentsFacts/NotEmptyMessageFacts.cs
+++ b/tests/unit/Validations.Tests/ArgumentsFacts/NotEmptyMessageFacts.cs
@@ -1,0 +1,129 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using System;
+
+namespace Triplex.Validations.Tests.ArgumentsFacts
+{
+    internal static class NotEmptyMessageFacts
+    {
+        private const string CustomMessage = "Can't be null or empty from test case";
+
+        [TestFixture]
+        internal sealed class WithInvalidCustomMessage
+        {
+            [Test]
+            public void With_Null_Throws_ArgumentNullException()
+            {
+                string someInput = "dummyValue";
+                Assert.That(() => Arguments.NotEmpty(someInput, nameof(someInput), null!),
+                    Throws.ArgumentNullException
+                    .With.Property(nameof(ArgumentNullException.ParamName)).EqualTo("customMessage"));
+            }
+
+            [Test]
+            public void With_Empty_Throws_ArgumentOutOfRangeException()
+            {
+                string someInput = "dummyValue";
+                Assert.That(() => Arguments.NotEmpty(someInput, nameof(someInput), string.Empty),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property(nameof(ArgumentOutOfRangeException.ParamName)).EqualTo("customMessage"));
+            }
+        }
+
+        internal sealed class WithInvalidParamName : BaseFixtureForOptionalCustomMessage
+        {
+            public WithInvalidParamName(bool useCustomErrorMessage) : base(useCustomErrorMessage)
+            {
+            }
+
+            [Test]
+            public void With_Null_ParamName_Throws_ArgumentNullException()
+            {
+                Assert.That(() => NotNullOrEmpty("dummyValue", null, CustomMessage, UseCustomErrorMessage),
+                    Throws.ArgumentNullException
+                    .With.Property(nameof(ArgumentNullException.ParamName)).EqualTo("paramName"));
+            }
+
+            [Test]
+            public void With_Empty_ParamName_Throws_ArgumentOutOfRangeException()
+            {
+                Assert.That(() => NotNullOrEmpty("dummyValue", string.Empty, CustomMessage, UseCustomErrorMessage),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property(nameof(ArgumentOutOfRangeException.ParamName)).EqualTo("paramName")
+                    .And.Property(nameof(ArgumentOutOfRangeException.ActualValue)).EqualTo(0));
+            }
+        }
+
+        internal sealed class WithInvalidValueMessage : BaseFixtureForOptionalCustomMessage
+        {
+            public WithInvalidValueMessage(bool useCustomErrorMessage) : base(useCustomErrorMessage)
+            {
+            }
+
+            [Test]
+            public void With_Null_Value_Throws_ArgumentNullException()
+            {
+                string? dummyParam = null;
+
+                Constraint exceptionConstraint = AddMessageConstraint(
+                    Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName)).EqualTo(nameof(dummyParam)),
+                    UseCustomErrorMessage);
+
+                Assert.That(() => NotNullOrEmpty(dummyParam, nameof(dummyParam), CustomMessage, UseCustomErrorMessage), exceptionConstraint);
+            }
+
+            [Test]
+            public void With_Empty_Value_Throws_ArgumentOutOfRangeException()
+            {
+                string? dummyParam = string.Empty;
+
+                Constraint exceptionConstraint = AddMessageConstraint(
+                    Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property(nameof(ArgumentNullException.ParamName)).EqualTo(nameof(dummyParam)),
+                    UseCustomErrorMessage);
+
+                Assert.That(() => NotNullOrEmpty(dummyParam, nameof(dummyParam), CustomMessage, UseCustomErrorMessage), exceptionConstraint);
+            }
+
+            private static Constraint AddMessageConstraint(in Constraint messageConstraint, in bool useCustomErrorMessage)
+                => useCustomErrorMessage ? messageConstraint.With.Message.StartsWith(CustomMessage) : messageConstraint;
+        }
+
+        internal sealed class WithValidValueMessage : BaseFixtureForOptionalCustomMessage
+        {
+            public WithValidValueMessage(bool useCustomErrorMessage) : base(useCustomErrorMessage)
+            {
+            }
+
+            [TestCase(" ")]
+            [TestCase("\n")]
+            [TestCase("\r")]
+            [TestCase("\t")]
+            [TestCase("\n\r\t ")]
+            public void With_Common_White_Space_Sequences_Value_Throws_Nothing(in string? dummyParam)
+            {
+                string myDummyValue = NotNullOrEmpty(dummyParam, nameof(dummyParam), CustomMessage, UseCustomErrorMessage);
+
+                Assert.That(myDummyValue, Is.SameAs(dummyParam));
+            }
+
+            [TestCase("peter")]
+            [TestCase("parker ")]
+            [TestCase(" Peter Parker Is Spiderman ")]
+            public void With_Non_Empty_Values_Throws_Nothing(in string? someParam)
+            {
+                string myDummyValue = NotNullOrEmpty(someParam, nameof(someParam), CustomMessage, UseCustomErrorMessage);
+
+                Assert.That(myDummyValue, Is.SameAs(someParam));
+            }
+        }
+
+        private static string NotNullOrEmpty(
+            in string? value, 
+            in string? paramName, 
+            in string? customMessage, 
+            in bool useCustomErrorMessage)
+            => useCustomErrorMessage ? Arguments.NotEmpty(value, paramName!, customMessage!) 
+                                     : Arguments.NotEmpty(value, paramName!);
+    }
+}

--- a/tests/unit/Validations.Tests/ArgumentsFacts/NotEmptyOrWhiteSpaceOnlyMessageFacts.cs
+++ b/tests/unit/Validations.Tests/ArgumentsFacts/NotEmptyOrWhiteSpaceOnlyMessageFacts.cs
@@ -1,0 +1,117 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace Triplex.Validations.Tests.ArgumentsFacts
+{
+    [TestFixture]
+    internal sealed class NotEmptyOrWhiteSpaceOnlyMessageFacts
+    {
+        private const string CustomMessage = "Some error message, caller provided.";
+
+        [Test]
+        public void With_Null_CustomError_Throws_ArgumentNullException()
+        {
+            string? dummyParam = "Hello world!";
+
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly(dummyParam, nameof(dummyParam), null!), 
+                Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName)).EqualTo("customMessage"));
+        }
+
+        [Test]
+        public void With_Empty_CustomError_Throws_ArgumentOutOfRangeException()
+        {
+            string? dummyParam = "Hello world!";
+
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly(dummyParam, nameof(dummyParam), string.Empty),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                .With.Property(nameof(ArgumentNullException.ParamName)).EqualTo("customMessage"));
+        }
+
+        [TestCase(" ")]
+        [TestCase("\n")]
+        [TestCase("\r")]
+        [TestCase("\t")]
+        [TestCase("\n\r\t ")]
+        public void With_Common_White_Space_CustomError_Throws_ArgumentFormatException(in string? someErrorMessage)
+        {
+            string? dummyParam = "Hello world!";
+            string? someErrorMessageCopy = someErrorMessage;
+
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly(dummyParam, nameof(dummyParam), someErrorMessageCopy!),
+                Throws.InstanceOf<Exceptions.ArgumentFormatException>()
+                .With.Property(nameof(ArgumentException.ParamName)).EqualTo("customMessage"));
+        }
+       
+        [Test]
+        public void With_Null_Value_Throws_ArgumentNullException()
+        {
+            string? dummyParam = null;
+
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly(dummyParam, nameof(dummyParam), CustomMessage),
+                Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName)).EqualTo(nameof(dummyParam)));
+        }
+
+        [Test]
+        public void With_Empty_Value_Throws_ArgumentOutOfRangeException()
+        {
+            string? dummyParam = string.Empty;
+
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly(dummyParam, nameof(dummyParam), CustomMessage),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                .With.Property(nameof(ArgumentNullException.ParamName)).EqualTo(nameof(dummyParam)));
+        }
+
+        [TestCase(" ")]
+        [TestCase("\n")]
+        [TestCase("\r")]
+        [TestCase("\t")]
+        [TestCase("\n\r\t ")]
+        public void With_Common_White_Space_Value_Throws_ArgumentFormatException(in string? dummyParam)
+        {
+            string? dummyParamValue = dummyParam;
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly(dummyParamValue, nameof(dummyParam), CustomMessage),
+                Throws.InstanceOf<Exceptions.ArgumentFormatException>()
+                .With.Property(nameof(ArgumentException.ParamName)).EqualTo(nameof(dummyParam)));
+        }
+
+        [TestCase("peter")]
+        [TestCase("parker ")]
+        [TestCase(" Peter Parker Is Spiderman ")]
+        public void With_Valid_Values_Returns_Input_Value(in string? someValue)
+        {
+            string validatedValue = Arguments.NotEmptyOrWhiteSpaceOnly(someValue, nameof(someValue), CustomMessage);
+
+            Assert.That(validatedValue, Is.SameAs(someValue));
+        }
+
+        [Test]
+        public void With_Null_ParamName_Throws_ArgumentNullException()
+        {
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly("dummyValue", null!, CustomMessage),
+                Throws.ArgumentNullException
+                .With.Property(nameof(ArgumentNullException.ParamName)).EqualTo("paramName"));
+        }
+
+        [Test]
+        public void With_Empty_ParamName_Throws_ArgumentOutOfRangeException()
+        {
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly("dummyValue", string.Empty, CustomMessage),
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                .With.Property(nameof(ArgumentOutOfRangeException.ParamName)).EqualTo("paramName")
+                .And.Property(nameof(ArgumentOutOfRangeException.ActualValue)).EqualTo(0));
+        }
+
+        [TestCase(" ")]
+        [TestCase("\n")]
+        [TestCase("\r")]
+        [TestCase("\t")]
+        [TestCase("\n\r\t ")]
+        public void With_Empty_ParamName_Throws_ArgumentOutOfRangeException(in string? paramName)
+        {
+            string? paramNameValue = paramName;
+            Assert.That(() => Arguments.NotEmptyOrWhiteSpaceOnly("dummyValue", paramNameValue!, CustomMessage),
+                Throws.InstanceOf<Exceptions.ArgumentFormatException>()
+                .With.Property(nameof(Exceptions.ArgumentFormatException.ParamName)).EqualTo("paramName"));
+        }
+    }
+}


### PR DESCRIPTION
Breaking Changes
  - Obsolete members from `Triplex.Validations.Arguments`:
    - `string NotNullEmptyOrWhiteSpaceOnly(in string?, in string)`
    - `string NotNullEmptyOrWhiteSpaceOnly(in string?, in string, in string)`
    - `string NotNullOrEmpty(in string?, in string)`
    - `string NotNullOrEmpty(in string?, in string, in string)`

Features
  - Introduce implicit null check for `NotNullEmptyOrWhiteSpaceOnly` (now `NotEmptyOrWhiteSpaceOnly`) and `NotNullOrEmpty` (now `NotEmpty`).